### PR TITLE
chore: add vscode code-workspace with project recommendations

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2",
+    "ignorePaths": [
+        "node_modules",
+        "dist",
+        "build",
+        "public",
+        ".env",
+        ".gitignore",
+        ".gitattributes",
+        ".vscode",
+        "package-lock.json",
+        "cspell.json",
+        "project-sass.code-workspace",
+    ],
+    "dictionaryDefinitions": [],
+    "dictionaries": [],
+    "words": [],
+    "ignoreWords": [],
+    "import": []
+}

--- a/project-sass.code-workspace
+++ b/project-sass.code-workspace
@@ -14,6 +14,8 @@
 			"EditorConfig.EditorConfig",
             "laravel.vscode-laravel",
 			"streetsidesoftware.code-spell-checker",
+            "yoavbls.pretty-ts-errors",
+            "streetsidesoftware.code-spell-checker"
 		],
 		"unwantedRecommendations": []
 	},

--- a/project-sass.code-workspace
+++ b/project-sass.code-workspace
@@ -1,0 +1,29 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+	],
+	"launch": {
+		"version": "0.2.0",
+		"configurations": []
+	},
+	"extensions": {
+		"recommendations": [
+			"valeryanm.vscode-phpsab",
+			"EditorConfig.EditorConfig",
+            "laravel.vscode-laravel",
+			"streetsidesoftware.code-spell-checker",
+		],
+		"unwantedRecommendations": []
+	},
+	"settings": {
+		"[php]": {
+			"editor.detectIndentation": true,
+			"editor.useTabStops": true,
+			"editor.formatOnSave": true,
+			"editor.insertSpaces": false,
+			"editor.defaultFormatter": "valeryanm.vscode-phpsab"
+		},
+	}
+}


### PR DESCRIPTION
I think we can extend it later on
ideally would be nice to have PHPCS so we can use VSCode extension for php linting on the editor

this workspace file allow us to open the project through this file, and automatically have in vscode a set of rules and extensions to be used on the project