### PR TITLE
refactor(activity factory): handle dynamic paths and durations

### DIFF
--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -20,11 +20,13 @@ final class ActivityFactory extends Factory
      */
     public function definition(): array
     {
+        $path = '/'.fake()->slug();
+
         return [
             'project_id' => Project::factory(),
             'events' => [
-                EventType::view('/about'),
-                EventType::viewDuration('/about', 2),
+                EventType::view($path),
+                EventType::viewDuration($path, fake()->numberBetween(2, 30)),
             ],
         ];
     }

--- a/tests/Unit/Models/ActivityTest.php
+++ b/tests/Unit/Models/ActivityTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\EventType;
 use App\Models\Activity;
 use App\Models\Project;
 use Pest\Expectation;
@@ -26,21 +27,29 @@ it('belongs to a project', function () {
 });
 
 it('casts events to array', function () {
-    $activity = Activity::factory()->create();
+    $path = '/'.fake()->slug();
+    $seconds = fake()->numberBetween(2, 30);
+
+    $activity = Activity::factory()->state([
+        'events' => [
+            EventType::view($path),
+            EventType::viewDuration($path, $seconds),
+        ],
+    ])->create();
 
     expect($activity->events)->toBeArray()->toHaveCount(2)
         ->sequence(
             fn (Expectation $event) => $event->toBe([
                 'type' => 'view',
                 'payload' => [
-                    'url' => '/about',
+                    'url' => $path,
                 ],
             ]),
             fn (Expectation $event) => $event->toBe([
                 'type' => 'view_duration',
                 'payload' => [
-                    'url' => '/about',
-                    'seconds' => '2',
+                    'url' => $path,
+                    'seconds' => (string) $seconds,
                 ],
             ]),
         );


### PR DESCRIPTION
The activity factory now generates dynamic paths and random durations. Make's it easier to use the factory to generate lots of fake activity.

```php
$project = Project::factory()->create(); 
Activity::factory()->count(100)->create(['project_id' => $project->id]);
```

Will now give data like this in the database
![Skjermbilde 2025-01-18 kl  13 58 03](https://github.com/user-attachments/assets/9c2bd2ca-7fc7-45e0-ac9b-de398f8bed8d)
