### PR TITLE
test(arch): basic arch tests

### DIFF
--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -2,15 +2,103 @@
 
 declare(strict_types=1);
 
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\ServiceProvider;
+
 arch()->preset()->php();
 arch()->preset()->laravel();
 arch()->preset()->security();
 
-arch('controllers')
-    ->expect('App\Http\Controllers')
-    ->toExtendNothing()
-    ->not->toBeUsed();
+arch('strict types')
+    ->expect('App')
+    ->toUseStrictTypes();
 
 arch('exceptions')
     ->expect('App\Exceptions')
     ->toImplement('Throwable');
+
+arch('avoid mutation')
+    ->expect('App')
+    ->classes()
+    ->toBeReadonly()
+    ->ignoring([
+        'App\Exceptions',
+        'App\Jobs',
+        'App\Models',
+        'App\Providers',
+        'App\Services',
+    ]);
+
+arch('avoid inheritance')
+    ->expect('App')
+    ->classes()
+    ->toExtendNothing()
+    ->ignoring([
+        'App\Models',
+        'App\Exceptions',
+        'App\Jobs',
+        'App\Providers',
+        'App\Services',
+    ]);
+
+arch('annotations')
+    ->expect('App')
+    ->toHavePropertiesDocumented()
+    ->toHaveMethodsDocumented();
+
+arch('avoid open for extension')
+    ->expect('App')
+    ->classes()
+    ->toBeFinal();
+
+arch('avoid abstraction')
+    ->expect('App')
+    ->not->toBeAbstract();
+
+arch('enums')
+    ->expect('App\Enums')
+    ->toBeEnums();
+
+arch('factories')
+    ->expect('Database\Factories')
+    ->toExtend(Factory::class)
+    ->toHaveMethod('definition')
+    ->toOnlyBeUsedIn([
+        'App\Models',
+    ]);
+
+arch('globals')
+    ->expect(['dd', 'dump', 'ray', 'die', 'var_dump', 'sleep'])
+    ->not->toBeUsed();
+
+arch('jobs')
+    ->expect('App\Jobs')
+    ->toHaveMethod('handle')
+    ->toHaveConstructor()
+    ->toImplement(ShouldQueue::class);
+
+arch('models')
+    ->expect('App\Models')
+    ->toHaveMethod('casts')
+    ->toExtend(Model::class)
+    ->toOnlyBeUsedIn([
+        'App\Http',
+        'App\Jobs',
+        'App\Models',
+        'App\Providers',
+        'App\Actions',
+        'App\Services',
+        'Database\Factories',
+        'Database\Seeders', // will be removed in the next PR as removing it gets outside of this PR scope
+    ]);
+
+arch('providers')
+    ->expect('App\Providers')
+    ->toExtend(ServiceProvider::class)
+    ->not->toBeUsed();
+
+arch('actions')
+    ->expect('App\Actions')
+    ->toHaveMethod('handle');

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -15,14 +15,6 @@ arch('controllers')
     ->expect('App\Http\Controllers')
     ->not->toBeUsed();
 
-arch('strict types')
-    ->expect('App')
-    ->toUseStrictTypes();
-
-arch('exceptions')
-    ->expect('App\Exceptions')
-    ->toImplement('Throwable');
-
 arch('avoid mutation')
     ->expect('App')
     ->classes()
@@ -61,10 +53,6 @@ arch('avoid abstraction')
     ->expect('App')
     ->not->toBeAbstract();
 
-arch('enums')
-    ->expect('App\Enums')
-    ->toBeEnums();
-
 arch('factories')
     ->expect('Database\Factories')
     ->toExtend(Factory::class)
@@ -73,20 +61,9 @@ arch('factories')
         'App\Models',
     ]);
 
-arch('globals')
-    ->expect(['dd', 'dump', 'ray', 'die', 'var_dump', 'sleep'])
-    ->not->toBeUsed();
-
-arch('jobs')
-    ->expect('App\Jobs')
-    ->toHaveMethod('handle')
-    ->toHaveConstructor()
-    ->toImplement(ShouldQueue::class);
-
 arch('models')
     ->expect('App\Models')
     ->toHaveMethod('casts')
-    ->toExtend(Model::class)
     ->toOnlyBeUsedIn([
         'App\Http',
         'App\Jobs',
@@ -97,11 +74,6 @@ arch('models')
         'Database\Factories',
         'Database\Seeders', // will be removed in the next PR as removing it gets outside of this PR scope
     ]);
-
-arch('providers')
-    ->expect('App\Providers')
-    ->toExtend(ServiceProvider::class)
-    ->not->toBeUsed();
 
 arch('actions')
     ->expect('App\Actions')

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -11,6 +11,10 @@ arch()->preset()->php();
 arch()->preset()->laravel();
 arch()->preset()->security();
 
+arch('controllers')
+    ->expect('App\Http\Controllers')
+    ->not->toBeUsed();
+
 arch('strict types')
     ->expect('App')
     ->toUseStrictTypes();

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -2,10 +2,7 @@
 
 declare(strict_types=1);
 
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\ServiceProvider;
 
 arch()->preset()->php();
 arch()->preset()->laravel();


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Panalyse team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Creates basic architecture tests.

`arch('controllers')->toExtendNothing()` removed as it's already handled by `avoid inheritance`.
